### PR TITLE
chore: remove deprecated rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "postcss-styled-syntax": "0.6.4",
-        "stylelint-config-standard": "36.0.0",
-        "stylelint-config-styled-components": "^0.1.1"
+        "stylelint-config-standard": "36.0.0"
       },
       "devDependencies": {
         "@cybozu/eslint-config": "23.0.0",
@@ -8638,11 +8637,6 @@
       "peerDependencies": {
         "stylelint": "^16.1.0"
       }
-    },
-    "node_modules/stylelint-config-styled-components": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-styled-components/-/stylelint-config-styled-components-0.1.1.tgz",
-      "integrity": "sha512-z5Xz/9GmvxO6e/DLzBMwkB85zHxEEjN6K7Cj80Bi+o/9vR9eS3GX3E9VuMnX9WLFYulqbqLtTapGGY28JBiy9Q=="
     },
     "node_modules/stylelint/node_modules/ansi-regex": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "postcss-styled-syntax": "0.6.4",
-    "stylelint-config-standard": "36.0.0",
-    "stylelint-config-styled-components": "^0.1.1"
+    "stylelint-config-standard": "36.0.0"
   },
   "devDependencies": {
     "@cybozu/eslint-config": "23.0.0",

--- a/styled-components.js
+++ b/styled-components.js
@@ -1,7 +1,10 @@
 export default {
-  extends: ["./index.js", "stylelint-config-styled-components"],
+  extends: ["./index.js"],
   customSyntax: "postcss-styled-syntax",
   rules: {
+    "no-empty-source": null,
+    "property-no-vendor-prefix": true,
+    "value-no-vendor-prefix": true,
     // These rules have problems with styled-components
     // This rule cannot recognize template literals with line feeds properly.
     // Error

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -67,14 +67,6 @@ exports[`should verify CSS in styled-components 1`] = `
 [
   [
     {
-      "column": 30,
-      "endColumn": 2,
-      "endLine": 21,
-      "line": 6,
-      "rule": "no-missing-end-of-source-newline",
-      "severity": "error",
-    },
-    {
       "column": 24,
       "endColumn": 26,
       "endLine": 10,


### PR DESCRIPTION
- Remove dependency of [stylelint-config-styled-components](https://github.com/styled-components/stylelint-config-styled-components) to remove deprecated rule `no-missing-end-of-source-newline`.
- This package contains setting about this rule, and this package is no longer maintained.
- `no-missing-end-of-source-newline` rule is deprecated on StyleLint v15 and removed on StyleLint v16.